### PR TITLE
Cast hyperparameters from config to numeric types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,74 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/
+
+# Virtual environments
+.venv/
+ENV/
+/env/
+venv/
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+
+# Logs
+*.log
+
+# Android emulator artifacts
+*.apk
+*.obb
+
+# Secrets
+.env
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        args: [--fix]
+        language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# Subway Surfers AI
+
+An open-source project to train a reinforcement-learning agent to play the original *Subway Surfers* game through an Android emulator. The project aims to be cross-platform (macOS and Windows) and uses a virtual Python environment for development.
+
+## Getting Started
+
+### 1. Create a virtual environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\\Scripts\\activate
+```
+
+### 2. Install dependencies
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 3. Set up the Android emulator
+
+Install [Android Studio](https://developer.android.com/studio) and configure a device with *Subway Surfers*. Make sure the `adb` command is available in your PATH.
+
+### 4. Interact with the emulator
+
+The `ADBController` class offers a minimal wrapper around the `adb` binary for screen capture and input events. Example:
+
+```python
+from src.env import ADBController
+
+ctrl = ADBController()
+image_bytes = ctrl.screencap()  # PNG bytes of the current screen
+ctrl.tap(100, 200)              # tap at x=100, y=200
+```
+
+### 5. Run formatting and linting
+
+The project uses [pre-commit](https://pre-commit.com/) hooks for formatting and linting.
+
+```bash
+pre-commit install
+pre-commit run --files $(git ls-files '*.py')
+```
+
+### 6. Train the baseline agent
+
+With the emulator running and *Subway Surfers* open, launch training:
+
+```bash
+python scripts/run_training.py --config configs/default.yaml --model-path models/dqn_subway_agent
+```
+
+### 7. Play using a trained model
+
+After training, watch the agent play:
+
+```bash
+python scripts/play_agent.py --model-path models/dqn_subway_agent
+```
+
+## Project Structure
+
+```
+├── src/
+│   ├── agent/        # RL algorithms and models
+│   ├── env/          # Emulator interface and wrappers
+│   └── training/     # Training loops and utilities
+├── configs/          # Hyper-parameter configs
+├── scripts/          # Helper scripts (run training, play agent)
+├── tests/            # Unit tests
+└── docs/             # Additional documentation
+```
+
+## Notes
+
+- Keep API keys or other secrets in a local `.env` file (ignored by git).
+- The repository does **not** include any game assets.
+- For sensitive operations (e.g., downloading the game APK), run commands locally and do not commit them.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,0 +1,6 @@
+# Default hyper-parameters for training
+batch_size: 32
+learning_rate: 3e-4
+gamma: 0.99
+buffer_size: 100000
+train_steps: 1000000

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Overview
+
+This document will track design decisions and architecture diagrams for the Subway Surfers AI project.
+
+- **Environment**: Interfaces with Android emulator via ADB, captures frames, and sends actions.
+  - `ADBController` provides a thin subprocess-based wrapper around the `adb` binary for
+    cross-platform screen capture and input events.
+  - `SubwaySurfersEnv` exposes a Gymnasium-compatible interface built on top of
+    `ADBController` for training and evaluation.
+- **Agent**: Reinforcement learning algorithms (starting with DQN) implemented in PyTorch.
+  - `DQNAgent` wraps the Stable-Baselines3 DQN implementation and provides a
+    small API for training and action selection.
+- **Training**: Scripts and utilities to optimize the agent.
+  - `run_training.py` reads hyper-parameters from a YAML config and saves the
+    trained model for later evaluation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+adbutils
+numpy
+pillow
+opencv-python
+pyyaml
+torch
+stable-baselines3
+gymnasium

--- a/scripts/play_agent.py
+++ b/scripts/play_agent.py
@@ -1,0 +1,46 @@
+"""Run a trained agent inside the Android emulator."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running as a script without installing the package
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.agent import DQNAgent  # noqa: E402
+from src.env import SubwaySurfersEnv  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Play using a trained model")
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=Path("models/dqn_subway_agent"),
+        help="Path to the trained model",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    env = SubwaySurfersEnv()
+    agent = DQNAgent.load(str(args.model_path), env)
+
+    obs, _ = env.reset()
+    terminated = False
+    while not terminated:
+        action = agent.act(obs)
+        obs, _, terminated, truncated, _ = env.step(action)
+        terminated = terminated or truncated
+
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -1,0 +1,68 @@
+"""Train a DQN agent on the Subway Surfers environment."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# Allow running as a script without installing the package
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.agent import DQNAgent  # noqa: E402
+from src.env import SubwaySurfersEnv  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train the Subway Surfers agent")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/default.yaml"),
+        help="Path to hyper-parameter configuration file",
+    )
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=Path("models/dqn_subway_agent"),
+        help="Where to store the trained model",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    with args.config.open() as fh:
+        cfg = yaml.safe_load(fh)
+
+    # ``yaml.safe_load`` treats values such as ``3e-4`` as strings under
+    # the YAML 1.2 specification.  Cast numeric hyper-parameters explicitly so
+    # that Stable-Baselines3 receives proper ``float``/``int`` types.
+    learning_rate = float(cfg["learning_rate"])
+    buffer_size = int(cfg["buffer_size"])
+    gamma = float(cfg["gamma"])
+    batch_size = int(cfg["batch_size"])
+    train_steps = int(cfg["train_steps"])
+
+    env = SubwaySurfersEnv()
+    agent = DQNAgent(
+        env,
+        learning_rate=learning_rate,
+        buffer_size=buffer_size,
+        gamma=gamma,
+        batch_size=batch_size,
+    )
+    agent.train(train_steps)
+
+    args.model_path.parent.mkdir(parents=True, exist_ok=True)
+    agent.save(str(args.model_path))
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Reinforcement learning agents for Subway Surfers."""
+
+from .dqn_agent import DQNAgent
+
+__all__ = ["DQNAgent"]

--- a/src/agent/dqn_agent.py
+++ b/src/agent/dqn_agent.py
@@ -1,0 +1,64 @@
+"""Baseline DQN agent using stable-baselines3.
+
+This thin wrapper exposes a minimal API around :class:`stable_baselines3.DQN`
+so that training and inference logic can be encapsulated in a lightweight
+object. The agent is instantiated with a Gymnasium environment and can be
+trained or used to produce actions given observations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gymnasium import Env
+from stable_baselines3 import DQN
+
+
+class DQNAgent:
+    """Deep Q-Network agent powered by Stable-Baselines3."""
+
+    def __init__(
+        self, env: Env, *, policy: str = "CnnPolicy", **dqn_kwargs: Any
+    ) -> None:
+        """Create a new DQN agent.
+
+        Parameters
+        ----------
+        env:
+            Gymnasium environment the agent will interact with.
+        policy:
+            Policy architecture. ``"CnnPolicy"`` expects image observations while
+            ``"MlpPolicy"`` works with vector observations. Defaults to
+            ``"CnnPolicy"``.
+        **dqn_kwargs:
+            Additional keyword arguments forwarded to
+            :class:`stable_baselines3.DQN`.
+        """
+
+        self.env = env
+        # ``verbose`` defaults to 0 if not provided to keep logs quiet by default.
+        self.model = DQN(
+            policy, env, verbose=dqn_kwargs.pop("verbose", 0), **dqn_kwargs
+        )
+
+    def train(self, total_timesteps: int) -> None:
+        """Train the agent for ``total_timesteps`` environment steps."""
+        self.model.learn(total_timesteps=total_timesteps)
+
+    def act(self, observation: Any) -> int:
+        """Return the action selected by the current policy for ``observation``."""
+        action, _ = self.model.predict(observation, deterministic=True)
+        return int(action)
+
+    def save(self, path: str) -> None:
+        """Persist model parameters to ``path``."""
+        self.model.save(path)
+
+    @classmethod
+    def load(cls, path: str, env: Env) -> "DQNAgent":
+        """Load a saved agent from ``path`` and attach ``env``."""
+        model = DQN.load(path, env=env)
+        agent = cls.__new__(cls)
+        agent.env = env
+        agent.model = model
+        return agent

--- a/src/env/__init__.py
+++ b/src/env/__init__.py
@@ -1,0 +1,6 @@
+"""Environment utilities for interacting with the Subway Surfers emulator."""
+
+from .adb_controller import ADBController
+from .subway_env import SubwaySurfersEnv
+
+__all__ = ["ADBController", "SubwaySurfersEnv"]

--- a/src/env/adb_controller.py
+++ b/src/env/adb_controller.py
@@ -1,0 +1,69 @@
+"""ADB-based interface for interacting with the Android emulator.
+
+This module provides a thin wrapper around the ``adb`` command-line tool to
+capture emulator frames and send tap or swipe inputs.  It relies only on the
+standard library and therefore works on both macOS and Windows, provided the
+``adb`` binary is available in the ``PATH``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from subprocess import run, CompletedProcess
+from typing import List, Optional
+
+
+@dataclass
+class ADBController:
+    """Minimal wrapper for issuing commands to an Android emulator.
+
+    Parameters
+    ----------
+    adb_path:
+        Path to the ``adb`` executable.  Defaults to ``"adb"`` and therefore
+        expects ``adb`` to be discoverable in ``PATH``.
+    device_id:
+        Optional serial of the target emulator/device.  If omitted the first
+        available device will be used.
+    """
+
+    adb_path: str = "adb"
+    device_id: Optional[str] = None
+
+    def _prefix(self) -> List[str]:
+        """Build the base adb command list."""
+        cmd = [self.adb_path]
+        if self.device_id:
+            cmd.extend(["-s", self.device_id])
+        return cmd
+
+    def screencap(self) -> bytes:
+        """Return a PNG screenshot taken from the emulator.
+
+        This method executes ``adb exec-out screencap -p`` and returns the raw
+        PNG bytes.  The caller is responsible for decoding the image (e.g., via
+        ``Pillow`` or ``cv2``).
+        """
+
+        cmd = self._prefix() + ["exec-out", "screencap", "-p"]
+        result: CompletedProcess[bytes] = run(cmd, check=True, capture_output=True)
+        return result.stdout
+
+    def tap(self, x: int, y: int) -> None:
+        """Send a tap at the given coordinates."""
+        cmd = self._prefix() + ["shell", "input", "tap", str(x), str(y)]
+        run(cmd, check=True)
+
+    def swipe(self, x1: int, y1: int, x2: int, y2: int, duration_ms: int = 200) -> None:
+        """Swipe from (x1, y1) to (x2, y2) over ``duration_ms`` milliseconds."""
+        cmd = self._prefix() + [
+            "shell",
+            "input",
+            "swipe",
+            str(x1),
+            str(y1),
+            str(x2),
+            str(y2),
+            str(duration_ms),
+        ]
+        run(cmd, check=True)

--- a/src/env/subway_env.py
+++ b/src/env/subway_env.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass, field
+from typing import Dict, Tuple, Optional
+
+import gymnasium as gym
+import numpy as np
+from gymnasium import spaces
+from PIL import Image
+
+from .adb_controller import ADBController
+
+# Default swipe coordinates for a 1080x2400 portrait emulator screen.
+# Values are (x1, y1, x2, y2).
+DEFAULT_ACTION_COORDS: Dict[int, Tuple[int, int, int, int]] = {
+    0: (540, 1600, 140, 1600),  # left
+    1: (540, 1600, 940, 1600),  # right
+    2: (540, 1600, 540, 900),  # jump
+    3: (540, 1600, 540, 2000),  # roll
+}
+
+
+@dataclass
+class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
+    """Gymnasium-compatible environment for Subway Surfers.
+
+    The environment communicates with an Android emulator via ``ADBController``.
+    Observations are RGB frames resized to ``frame_size``.  Actions are discrete
+    swipes: left, right, jump, roll.
+    """
+
+    controller: Optional[ADBController] = None
+    frame_size: Tuple[int, int] = (160, 90)  # (width, height)
+    action_coords: Dict[int, Tuple[int, int, int, int]] = field(
+        default_factory=lambda: DEFAULT_ACTION_COORDS.copy()
+    )
+
+    metadata = {"render_modes": ["rgb_array"]}
+
+    def __post_init__(self) -> None:
+        self.controller = self.controller or ADBController()
+        width, height = self.frame_size
+        self.observation_space = spaces.Box(
+            low=0,
+            high=255,
+            shape=(height, width, 3),
+            dtype=np.uint8,
+        )
+        self.action_space = spaces.Discrete(len(self.action_coords))
+
+    # ------------------------------------------------------------------
+    def _get_frame(self) -> np.ndarray:
+        """Capture and preprocess the current emulator frame."""
+        png_bytes = self.controller.screencap()
+        image = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+        image = image.resize(self.frame_size, Image.BILINEAR)
+        return np.asarray(image, dtype=np.uint8)
+
+    # Gymnasium API ----------------------------------------------------
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        super().reset(seed=seed)
+        observation = self._get_frame()
+        return observation, {}
+
+    def step(self, action: int):
+        if action not in self.action_coords:
+            raise gym.error.InvalidAction(f"Invalid action: {action}")
+        x1, y1, x2, y2 = self.action_coords[action]
+        self.controller.swipe(x1, y1, x2, y2)
+        observation = self._get_frame()
+        reward = 0.0
+        terminated = False
+        truncated = False
+        info: Dict[str, float] = {}
+        return observation, reward, terminated, truncated, info
+
+    def render(self) -> np.ndarray:
+        return self._get_frame()
+
+    def close(self) -> None:  # pragma: no cover - nothing to clean up
+        return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration for package imports."""
+
+import pathlib
+import sys
+
+# Ensure the project root is on sys.path so ``import src`` works without installing the package.
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_adb_controller.py
+++ b/tests/test_adb_controller.py
@@ -1,0 +1,33 @@
+"""Tests for the ADBController."""
+
+from unittest import mock
+
+from src.env import ADBController
+
+
+def test_tap_invokes_adb_with_coordinates() -> None:
+    controller = ADBController(adb_path="adb", device_id="emulator-5554")
+    with mock.patch("src.env.adb_controller.run") as run_mock:
+        controller.tap(10, 20)
+        run_mock.assert_called_once_with(
+            [
+                "adb",
+                "-s",
+                "emulator-5554",
+                "shell",
+                "input",
+                "tap",
+                "10",
+                "20",
+            ],
+            check=True,
+        )
+
+
+def test_screencap_returns_bytes() -> None:
+    controller = ADBController()
+    fake_result = mock.Mock(stdout=b"pngbytes")
+    with mock.patch("src.env.adb_controller.run", return_value=fake_result) as run_mock:
+        data = controller.screencap()
+    run_mock.assert_called_once()
+    assert data == b"pngbytes"

--- a/tests/test_dqn_agent.py
+++ b/tests/test_dqn_agent.py
@@ -1,0 +1,48 @@
+"""Tests for the DQNAgent wrapper."""
+
+from __future__ import annotations
+
+import numpy as np
+import gymnasium as gym
+from gymnasium import spaces
+
+from src.agent import DQNAgent
+
+
+class DummyEnv(gym.Env):
+    """Minimal image-based environment for testing."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(
+            low=0, high=255, shape=(84, 84, 3), dtype=np.uint8
+        )
+        self.action_space = spaces.Discrete(4)
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
+        return np.zeros(self.observation_space.shape, dtype=np.uint8), {}
+
+    def step(self, action: int):
+        obs = np.zeros(self.observation_space.shape, dtype=np.uint8)
+        reward = 0.0
+        terminated = False
+        truncated = False
+        info: dict = {}
+        return obs, reward, terminated, truncated, info
+
+
+def test_dqn_agent_act() -> None:
+    env = DummyEnv()
+    agent = DQNAgent(
+        env,
+        policy="CnnPolicy",
+        buffer_size=1,
+        learning_starts=0,
+        train_freq=1,
+        gradient_steps=1,
+    )
+    obs, _ = env.reset()
+    action = agent.act(obs)
+    assert env.action_space.contains(action)

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,5 @@
+"""Placeholder test to ensure test suite runs."""
+
+
+def test_placeholder() -> None:
+    assert True

--- a/tests/test_subway_env.py
+++ b/tests/test_subway_env.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import io
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+from src.env import SubwaySurfersEnv, ADBController
+
+
+def _fake_png(color: int) -> bytes:
+    img = Image.new("RGB", (100, 100), (color, color, color))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_reset_returns_observation():
+    controller = Mock(spec=ADBController)
+    controller.screencap.return_value = _fake_png(0)
+    env = SubwaySurfersEnv(controller=controller, frame_size=(50, 50))
+    obs, info = env.reset()
+    assert obs.shape == (50, 50, 3)
+    assert info == {}
+
+
+@pytest.mark.parametrize(
+    "action,coords",
+    [
+        (0, (540, 1600, 140, 1600)),
+        (1, (540, 1600, 940, 1600)),
+        (2, (540, 1600, 540, 900)),
+        (3, (540, 1600, 540, 2000)),
+    ],
+)
+def test_step_swipe_called(action, coords):
+    controller = Mock(spec=ADBController)
+    controller.screencap.return_value = _fake_png(0)
+    env = SubwaySurfersEnv(controller=controller)
+    env.reset()
+    controller.screencap.return_value = _fake_png(255)
+    obs, reward, terminated, truncated, info = env.step(action)
+    controller.swipe.assert_called_once_with(*coords)
+    assert obs.shape == env.observation_space.shape
+    assert reward == 0.0
+    assert terminated is False
+    assert truncated is False
+    assert info == {}


### PR DESCRIPTION
## Summary
- avoid Stable-Baselines3 learning rate assertion by casting config values like "3e-4" to float/int before constructing `DQNAgent`

## Testing
- `python -m pre_commit run --files scripts/run_training.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac36ee0f88329bcbc07d8bdb95061