### PR TITLE
Stack grayscale frames

### DIFF
--- a/tests/test_subway_env.py
+++ b/tests/test_subway_env.py
@@ -27,7 +27,7 @@ def test_reset_returns_observation():
     controller.screencap.return_value = _fake_png(0)
     env = SubwaySurfersEnv(controller=controller, frame_size=(50, 50))
     obs, info = env.reset()
-    assert obs.shape == (50, 50, 3)
+    assert obs.shape == (50, 50, env.frame_stack)
     assert info == {}
 
 


### PR DESCRIPTION
## Summary
- maintain deque of grayscale frames and expose stacked observations
- update observation space to channel-last stack and preprocess to grayscale
- adjust environment tests for stacked frames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4391924008329a949f7645b5ee2de