### PR TITLE
Tune DQN learning and exploration

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,7 +1,9 @@
 # Default hyper-parameters for training
 batch_size: 32
-learning_rate: 3e-4
+learning_rate: 1e-4
 gamma: 0.99
 buffer_size: 100000
 train_steps: 1000000
 checkpoint_freq: 10000
+exploration_fraction: 0.2
+exploration_final_eps: 0.02

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -61,6 +61,8 @@ def main() -> None:
     gamma = float(cfg["gamma"])
     batch_size = int(cfg["batch_size"])
     train_steps = int(cfg["train_steps"])
+    exploration_fraction = float(cfg.get("exploration_fraction", 0.1))
+    exploration_final_eps = float(cfg.get("exploration_final_eps", 0.05))
 
     # Resolve model file (Stable-Baselines appends ``.zip`` if missing).
     model_file = args.model_path
@@ -91,6 +93,8 @@ def main() -> None:
                 buffer_size=buffer_size,
                 gamma=gamma,
                 batch_size=batch_size,
+                exploration_fraction=exploration_fraction,
+                exploration_final_eps=exploration_final_eps,
                 verbose=1,
                 tensorboard_log=str(log_dir),
             )


### PR DESCRIPTION
## Summary
- reduce learning rate to 1e-4 for steadier convergence
- extend ε-greedy exploration schedule and expose parameters via config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf07b082e08329bd50ac3e688cedbf