### PR TITLE
Ensure resumed training uses new hyperparameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ python scripts/run_training.py --config configs/default.yaml --model-path models
 
 The script prints training progress and automatically saves checkpoints under
 `models/checkpoints/`. If a model or checkpoint already exists, training
-resumes from the latest state and continues with the correct learning rate
-schedules. Rewards reflect **time survived while the game is actually playing**;
+resumes from the latest state and continues with the specified learning rate
+and exploration schedule. Rewards reflect **time survived while the game is actually playing**;
 time spent in menus or on crash screens does not contribute to the reward or
 episode length.
 

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -18,6 +18,7 @@ if str(ROOT) not in sys.path:
 
 from src.agent import DQNAgent  # noqa: E402
 from src.env import SubwaySurfersEnv  # noqa: E402
+from src.training.utils import update_dqn_hyperparameters  # noqa: E402
 
 
 def find_latest_checkpoint(model_file: Path) -> Path | None:
@@ -99,6 +100,14 @@ def main() -> None:
                 tensorboard_log=str(log_dir),
             )
             print("Initialized new agent")
+
+    # Apply potentially updated hyper-parameters when resuming training
+    update_dqn_hyperparameters(
+        agent.model,
+        learning_rate=learning_rate,
+        exploration_fraction=exploration_fraction,
+        exploration_final_eps=exploration_final_eps,
+    )
 
     # Setup checkpointing
     checkpoint_dir = model_file.parent / "checkpoints"

--- a/src/training/utils.py
+++ b/src/training/utils.py
@@ -1,0 +1,36 @@
+"""Utilities for training helpers."""
+
+from __future__ import annotations
+
+from stable_baselines3.common.utils import LinearSchedule
+
+
+def update_dqn_hyperparameters(
+    model,
+    *,
+    learning_rate: float,
+    exploration_fraction: float,
+    exploration_final_eps: float,
+) -> None:
+    """Update learning rate and exploration schedule for a loaded DQN model.
+
+    This is useful when resuming training with new hyper-parameters.
+    The optimizer's learning rate is updated and the epsilon-greedy schedule
+    is reset so that exploration anneals according to the new parameters.
+    """
+    # Update learning rate for the optimizer and schedule
+    model.learning_rate = learning_rate
+    model.lr_schedule = lambda _: learning_rate
+    for param_group in model.policy.optimizer.param_groups:
+        param_group["lr"] = learning_rate
+
+    # Reset exploration schedule
+    model.exploration_initial_eps = 1.0
+    model.exploration_final_eps = exploration_final_eps
+    model.exploration_fraction = exploration_fraction
+    model.exploration_schedule = LinearSchedule(
+        model.exploration_initial_eps,
+        model.exploration_final_eps,
+        model.exploration_fraction,
+    )
+    model.exploration_rate = model.exploration_initial_eps

--- a/tests/test_training_utils.py
+++ b/tests/test_training_utils.py
@@ -1,0 +1,70 @@
+"""Tests for training utility functions."""
+
+from __future__ import annotations
+
+import numpy as np
+import gymnasium as gym
+from gymnasium import spaces
+import pytest
+
+from src.agent import DQNAgent
+from src.training.utils import update_dqn_hyperparameters
+
+
+class DummyEnv(gym.Env):
+    """Minimal environment returning zero observations."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(
+            low=0, high=255, shape=(84, 84, 3), dtype=np.uint8
+        )
+        self.action_space = spaces.Discrete(2)
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
+        return np.zeros(self.observation_space.shape, dtype=np.uint8), {}
+
+    def step(self, action: int):
+        obs = np.zeros(self.observation_space.shape, dtype=np.uint8)
+        reward = 0.0
+        terminated = False
+        truncated = False
+        info: dict = {}
+        return obs, reward, terminated, truncated, info
+
+
+def test_update_dqn_hyperparameters() -> None:
+    env = DummyEnv()
+    agent = DQNAgent(
+        env,
+        policy="CnnPolicy",
+        buffer_size=1,
+        learning_starts=0,
+        train_freq=1,
+        gradient_steps=1,
+    )
+    model = agent.model
+
+    # Simulate previous training
+    model.exploration_rate = 0.2
+    model.policy.optimizer.param_groups[0]["lr"] = 1e-4
+
+    update_dqn_hyperparameters(
+        model,
+        learning_rate=1e-3,
+        exploration_fraction=0.5,
+        exploration_final_eps=0.1,
+    )
+
+    assert model.learning_rate == pytest.approx(1e-3)
+    assert all(
+        pg["lr"] == pytest.approx(1e-3) for pg in model.policy.optimizer.param_groups
+    )
+    assert model.exploration_rate == pytest.approx(1.0)
+    assert model.exploration_final_eps == pytest.approx(0.1)
+    assert model.exploration_fraction == pytest.approx(0.5)
+    schedule = model.exploration_schedule
+    assert schedule(1.0) == pytest.approx(1.0)
+    assert schedule(0.0) == pytest.approx(0.1)


### PR DESCRIPTION
## Summary
- refresh learning rate and exploration schedule when resuming DQN training
- add helper to update DQN model hyperparameters and test
- document that resumed runs apply the specified hyperparameters

## Testing
- `pre-commit run --files README.md scripts/run_training.py src/training/utils.py tests/test_training_utils.py`
- `pytest -q` *(fails: KeyboardInterrupt after success output)*


------
https://chatgpt.com/codex/tasks/task_e_68bff505e7208329a217ed4088b47486