### PR TITLE
Increase batch size for training configuration

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,5 +1,5 @@
 # Default hyper-parameters for training
-batch_size: 32
+batch_size: 64
 learning_rate: 1e-4
 gamma: 0.99
 buffer_size: 100000


### PR DESCRIPTION
## Summary
- raise `batch_size` from 32 to 64 in the default training config

## Testing
- `pre-commit run --files configs/default.yaml`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `/usr/bin/time -v python scripts/run_training.py --config configs/default.yaml` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'adb')*


------
https://chatgpt.com/codex/tasks/task_e_68c0176148b48329ac159af44cf4fbbe