### PR TITLE
Enable frame stacking for DQN agent

### DIFF
--- a/scripts/evaluate_agent.py
+++ b/scripts/evaluate_agent.py
@@ -9,6 +9,7 @@ import logging
 
 from stable_baselines3.common.evaluation import evaluate_policy
 from stable_baselines3.common.logger import configure
+from stable_baselines3.common.vec_env import DummyVecEnv, VecFrameStack
 
 # Allow running as a script without installing the package
 ROOT = Path(__file__).resolve().parents[1]
@@ -57,7 +58,8 @@ def main() -> None:
     if not model_path.suffix:
         model_path = model_path.with_suffix(".zip")
 
-    env = SubwaySurfersEnv()
+    base_env = DummyVecEnv([SubwaySurfersEnv])
+    env = VecFrameStack(base_env, n_stack=4)
     agent = DQNAgent.load(str(model_path), env)
 
     mean_reward, std_reward = evaluate_policy(

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -10,6 +10,7 @@ import logging
 import yaml
 from stable_baselines3.common.callbacks import CheckpointCallback
 from stable_baselines3.common.logger import configure
+from stable_baselines3.common.vec_env import DummyVecEnv, VecFrameStack
 
 # Allow running as a script without installing the package
 ROOT = Path(__file__).resolve().parents[1]
@@ -70,7 +71,9 @@ def main() -> None:
     if not model_file.suffix:
         model_file = model_file.with_suffix(".zip")
 
-    env = SubwaySurfersEnv()
+    # Stack consecutive frames to give the agent a sense of motion.
+    base_env = DummyVecEnv([SubwaySurfersEnv])
+    env = VecFrameStack(base_env, n_stack=4)
 
     log_dir = model_file.parent / "tb"
     log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- stack four consecutive frames using `VecFrameStack` to give the agent temporal context during training
- adapt evaluation and play scripts to load models with the stacked-frame environment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c302e37a5c8329b185de94af85f4c0