### PR TITLE
Handle observation space mismatch when loading agent

### DIFF
--- a/src/training/utils.py
+++ b/src/training/utils.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Tuple
+
 from stable_baselines3.common.utils import LinearSchedule
+
+from src.agent import DQNAgent
 
 
 def update_dqn_hyperparameters(
@@ -34,3 +39,36 @@ def update_dqn_hyperparameters(
         model.exploration_fraction,
     )
     model.exploration_rate = model.exploration_initial_eps
+
+
+def load_or_create_dqn_agent(
+    model_path: str | Path,
+    env,
+    **agent_kwargs,
+) -> Tuple[DQNAgent, bool]:
+    """Return a loaded DQNAgent or create a new one on failure.
+
+    Parameters
+    ----------
+    model_path:
+        Path to the saved model. If loading fails (e.g. due to mismatched
+        observation spaces), a new agent is instantiated instead.
+    env:
+        Environment to attach to the agent.
+    **agent_kwargs:
+        Keyword arguments forwarded to :class:`~src.agent.DQNAgent` when a new
+        agent must be created.
+
+    Returns
+    -------
+    Tuple[DQNAgent, bool]
+        The agent and a flag indicating whether the model was successfully
+        loaded (``True``) or a new agent was created (``False``).
+    """
+
+    try:
+        agent = DQNAgent.load(str(model_path), env)
+        return agent, True
+    except Exception:
+        agent = DQNAgent(env, **agent_kwargs)
+        return agent, False


### PR DESCRIPTION
## Summary
- add utility to load existing DQN agent or create fresh one on failure
- make training script fall back to new agent if loaded model's observation space differs
- test loader with mismatched observation spaces

## Testing
- `pytest tests/test_training_utils.py::test_load_or_create_dqn_agent_handles_space_mismatch -q`
- `pytest -q` *(fails: required KeyboardInterrupt but all tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e1a7ef588329bfaa2eb67b17cdb9