### PR TITLE
Log episode metrics to TensorBoard

### DIFF
--- a/src/env/subway_env.py
+++ b/src/env/subway_env.py
@@ -198,7 +198,11 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
             self._last_frame_time = now
             self._episode_reward += -1.0
             self._episode_length += 1
-            info = {"time_survived": self._elapsed_play_time}
+            info = {
+                "time_survived": self._elapsed_play_time,
+                "episode_reward": self._episode_reward,
+                "episode_length": self._episode_length,
+            }
             LOGGER.info(
                 "Game finished: length=%d, reward=%.2f",
                 self._episode_length,
@@ -247,7 +251,11 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
                 self._episode_length,
                 self._episode_reward,
             )
-            info = {"time_survived": self._elapsed_play_time}
+            info = {
+                "time_survived": self._elapsed_play_time,
+                "episode_reward": self._episode_reward,
+                "episode_length": self._episode_length,
+            }
             self._elapsed_play_time = 0.0
             self._episode_reward = 0.0
             self._episode_length = 0

--- a/src/training/__init__.py
+++ b/src/training/__init__.py
@@ -1,0 +1,3 @@
+from .callbacks import EpisodeMetricsCallback
+
+__all__ = ["EpisodeMetricsCallback"]

--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -1,0 +1,29 @@
+"""Training callbacks.
+
+This module contains callbacks used during training, such as logging
+per-episode metrics to TensorBoard.
+"""
+
+from __future__ import annotations
+
+from stable_baselines3.common.callbacks import BaseCallback
+
+
+class EpisodeMetricsCallback(BaseCallback):
+    """Log episode reward and length to TensorBoard."""
+
+    def _on_step(self) -> bool:  # pragma: no cover - simple wrapper
+        dones = self.locals.get("dones")
+        infos = self.locals.get("infos")
+        if dones is None or infos is None:
+            return True
+        for done, info in zip(dones, infos):
+            if done:
+                reward = info.get("episode_reward")
+                length = info.get("episode_length")
+                if reward is not None:
+                    self.logger.record("episode/reward", float(reward))
+                if length is not None:
+                    self.logger.record("episode/length", float(length))
+                self.logger.dump(step=self.num_timesteps)
+        return True

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,23 @@
+"""Tests for training callbacks."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from src.training import EpisodeMetricsCallback
+
+
+def test_episode_metrics_callback_logs():
+    cb = EpisodeMetricsCallback()
+    mock_logger = Mock()
+    cb.model = Mock()
+    cb.model.logger = mock_logger
+    cb.locals = {
+        "dones": [True],
+        "infos": [{"episode_reward": 1.0, "episode_length": 2}],
+    }
+    cb.num_timesteps = 42
+    cb._on_step()
+    mock_logger.record.assert_any_call("episode/reward", 1.0)
+    mock_logger.record.assert_any_call("episode/length", 2.0)
+    mock_logger.dump.assert_called_once_with(step=42)

--- a/tests/test_subway_env.py
+++ b/tests/test_subway_env.py
@@ -76,7 +76,11 @@ def test_step_detects_crash_and_skips(monkeypatch):
     controller.tap.assert_called_with(520, 1700)
     assert reward == -1.0
     assert terminated is True
-    assert info == {"time_survived": 0.0}
+    assert info == {
+        "time_survived": 0.0,
+        "episode_reward": -1.0,
+        "episode_length": 1,
+    }
 
 
 def test_template_matching_detects_menu(tmp_path):


### PR DESCRIPTION
## Summary
- include per-episode reward and length in env info
- log episode metrics to TensorBoard via EpisodeMetricsCallback
- cover callback with unit test

## Testing
- `pre-commit run --files src/env/subway_env.py src/training/callbacks.py src/training/__init__.py scripts/run_training.py tests/test_subway_env.py tests/test_callbacks.py`
- `pytest tests/test_adb_controller.py -q`
- `pytest tests/test_callbacks.py -q`
- `pytest tests/test_dqn_agent.py -q`
- `pytest tests/test_placeholder.py -q`
- `pytest tests/test_subway_env.py -q` (terminates with KeyboardInterrupt after reporting results)
- `pytest tests/test_training_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44690f96c8329a561da228109faa3