### PR TITLE
Make rewards independent of frame time

### DIFF
--- a/tests/test_subway_env.py
+++ b/tests/test_subway_env.py
@@ -58,7 +58,7 @@ def test_step_swipe_called(monkeypatch, action, coords):
     assert reward >= 0.0
     assert terminated is False
     assert truncated is False
-    assert info == {"time_survived": 0.0}
+    assert info == {"steps_survived": 1}
 
 
 def test_step_detects_crash_and_skips(monkeypatch):
@@ -77,7 +77,7 @@ def test_step_detects_crash_and_skips(monkeypatch):
     assert reward == -1.0
     assert terminated is True
     assert info == {
-        "time_survived": 0.0,
+        "steps_survived": 1,
         "episode_reward": -1.0,
         "episode_length": 1,
     }


### PR DESCRIPTION
## Summary
- Give a constant step reward and keep crash penalty
- Remove elapsed-time tracking and report steps survived in info
- Update environment tests for step-based reward

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c516dd28f08329ae475edbe85445fe