### PR TITLE
Add prioritized replay buffer and DQN integration

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -7,3 +7,7 @@ train_steps: 1000000
 checkpoint_freq: 10000
 exploration_fraction: 0.2
 exploration_final_eps: 0.02
+priority_alpha: 0.6
+priority_beta: 0.4
+priority_beta_increment: 0.001
+priority_eps: 1.0e-6

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -69,6 +69,10 @@ def main() -> None:
     train_steps = int(cfg["train_steps"])
     exploration_fraction = float(cfg.get("exploration_fraction", 0.1))
     exploration_final_eps = float(cfg.get("exploration_final_eps", 0.05))
+    priority_alpha = float(cfg.get("priority_alpha", 0.6))
+    priority_beta = float(cfg.get("priority_beta", 0.4))
+    priority_beta_increment = float(cfg.get("priority_beta_increment", 1e-3))
+    priority_eps = float(cfg.get("priority_eps", 1e-6))
 
     # Resolve model file (Stable-Baselines appends ``.zip`` if missing).
     model_file = args.model_path
@@ -90,6 +94,10 @@ def main() -> None:
         batch_size=batch_size,
         exploration_fraction=exploration_fraction,
         exploration_final_eps=exploration_final_eps,
+        priority_alpha=priority_alpha,
+        priority_beta=priority_beta,
+        priority_beta_increment=priority_beta_increment,
+        priority_eps=priority_eps,
         verbose=1,
         tensorboard_log=str(log_dir),
     )

--- a/src/agent/dqn_agent.py
+++ b/src/agent/dqn_agent.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 from gymnasium import Env
-from stable_baselines3 import DQN
+from .prioritized_dqn import PrioritizedDQN
 from stable_baselines3.common.callbacks import BaseCallback
 
 
@@ -38,7 +38,7 @@ class DQNAgent:
 
         self.env = env
         # ``verbose`` defaults to 0 if not provided to keep logs quiet by default.
-        self.model = DQN(
+        self.model = PrioritizedDQN(
             policy, env, verbose=dqn_kwargs.pop("verbose", 0), **dqn_kwargs
         )
 
@@ -76,7 +76,7 @@ class DQNAgent:
     @classmethod
     def load(cls, path: str, env: Env) -> "DQNAgent":
         """Load a saved agent from ``path`` and attach ``env``."""
-        model = DQN.load(path, env=env)
+        model = PrioritizedDQN.load(path, env=env)
         agent = cls.__new__(cls)
         agent.env = env
         agent.model = model

--- a/src/agent/prioritized_dqn.py
+++ b/src/agent/prioritized_dqn.py
@@ -1,0 +1,85 @@
+"""DQN variant with prioritized experience replay."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch as th
+import torch.nn.functional as F
+from stable_baselines3 import DQN
+
+from .prioritized_replay_buffer import (
+    PrioritizedReplayBuffer,
+    PrioritizedReplayBufferSamples,
+)
+
+
+class PrioritizedDQN(DQN):
+    """Deep Q-Network with prioritized replay buffer."""
+
+    def __init__(
+        self,
+        *args: Any,
+        priority_alpha: float = 0.6,
+        priority_beta: float = 0.4,
+        priority_beta_increment: float = 1e-3,
+        priority_eps: float = 1e-6,
+        **kwargs: Any,
+    ) -> None:
+        self.priority_beta_increment = priority_beta_increment
+        replay_buffer_kwargs = kwargs.pop("replay_buffer_kwargs", {})
+        replay_buffer_kwargs.update(
+            dict(alpha=priority_alpha, beta=priority_beta, eps=priority_eps)
+        )
+        super().__init__(
+            *args,
+            replay_buffer_class=PrioritizedReplayBuffer,
+            replay_buffer_kwargs=replay_buffer_kwargs,
+            **kwargs,
+        )
+
+    def train(self, gradient_steps: int, batch_size: int = 100) -> None:  # type: ignore[override]
+        self.policy.set_training_mode(True)
+        self._update_learning_rate(self.policy.optimizer)
+
+        losses = []
+        for _ in range(gradient_steps):
+            replay_data: PrioritizedReplayBufferSamples = self.replay_buffer.sample(
+                batch_size, env=self._vec_normalize_env
+            )
+            with th.no_grad():
+                next_q_values = self.q_net_target(replay_data.next_observations)
+                next_q_values, _ = next_q_values.max(dim=1)
+                next_q_values = next_q_values.reshape(-1, 1)
+                target_q_values = (
+                    replay_data.rewards
+                    + (1 - replay_data.dones) * self.gamma * next_q_values
+                )
+
+            current_q_values = self.q_net(replay_data.observations)
+            current_q_values = th.gather(
+                current_q_values, dim=1, index=replay_data.actions.long()
+            )
+
+            td_errors = F.smooth_l1_loss(
+                current_q_values, target_q_values, reduction="none"
+            )
+            loss = (td_errors * replay_data.weights).mean()
+            losses.append(loss.item())
+
+            self.policy.optimizer.zero_grad()
+            loss.backward()
+            th.nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+            self.policy.optimizer.step()
+
+            new_priorities = td_errors.detach().cpu().numpy().squeeze()
+            self.replay_buffer.update_priorities(replay_data.indices, new_priorities)
+            # Anneal beta towards 1.0
+            self.replay_buffer.beta = min(
+                1.0, self.replay_buffer.beta + self.priority_beta_increment
+            )
+
+        self._n_updates += gradient_steps
+        self.logger.record("train/n_updates", self._n_updates, exclude="tensorboard")
+        self.logger.record("train/loss", np.mean(losses))

--- a/src/agent/prioritized_replay_buffer.py
+++ b/src/agent/prioritized_replay_buffer.py
@@ -1,0 +1,105 @@
+"""Prioritized replay buffer for proportional prioritization.
+
+This implementation extends Stable-Baselines3's :class:`ReplayBuffer`
+with proportional prioritized sampling following
+`Schaul et al. (2016) <https://arxiv.org/abs/1511.05952>`_.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+import numpy as np
+import torch as th
+from stable_baselines3.common.buffers import ReplayBuffer
+from typing import NamedTuple
+
+from stable_baselines3.common.type_aliases import ReplayBufferSamples
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from stable_baselines3.common.vec_env import VecNormalize
+
+
+class PrioritizedReplayBuffer(ReplayBuffer):
+    """Replay buffer with proportional prioritization."""
+
+    def __init__(
+        self,
+        *args,
+        alpha: float = 0.6,
+        beta: float = 0.4,
+        eps: float = 1e-6,
+        **kwargs,
+    ) -> None:
+        """Create prioritized replay buffer.
+
+        Parameters
+        ----------
+        alpha:
+            Exponent determining how much prioritization is used (0 means
+            uniform sampling).
+        beta:
+            Initial value of beta for importance-sampling weights.
+        eps:
+            Small constant added to priorities to avoid zero probability.
+        """
+
+        super().__init__(*args, **kwargs)
+        self.alpha = alpha
+        self.beta = beta
+        self.eps = eps
+        self.priorities = np.zeros((self.buffer_size,), dtype=np.float32)
+        self.max_priority = 1.0
+
+    def add(self, *args, **kwargs) -> None:  # type: ignore[override]
+        """Add a new transition and assign it maximum priority."""
+        super().add(*args, **kwargs)
+        idx = (self.pos - 1) % self.buffer_size
+        self.priorities[idx] = self.max_priority
+
+    def _get_probabilities(self) -> np.ndarray:
+        if self.full:
+            priorities = self.priorities
+        else:
+            priorities = self.priorities[: self.pos]
+        scaled = priorities**self.alpha
+        return scaled / scaled.sum()
+
+    def sample(self, batch_size: int, env: Optional["VecNormalize"] = None):  # type: ignore[override]
+        """Sample a batch of experiences."""
+        probs = self._get_probabilities()
+        indices = np.random.choice(len(probs), batch_size, p=probs)
+        samples: ReplayBufferSamples = super()._get_samples(indices, env=env)
+        total = len(probs)
+        weights = (total * probs[indices]) ** (-self.beta)
+        weights /= weights.max()
+        w = th.as_tensor(weights, device=self.device).reshape(-1, 1)
+        return PrioritizedReplayBufferSamples(
+            samples.observations,
+            samples.actions,
+            samples.next_observations,
+            samples.dones,
+            samples.rewards,
+            w,
+            indices,
+            samples.discounts,
+        )
+
+    def update_priorities(self, indices: np.ndarray, priorities: np.ndarray) -> None:
+        """Update priorities of sampled transitions."""
+        priorities = np.abs(priorities) + self.eps
+        self.priorities[indices] = priorities
+        self.max_priority = max(self.max_priority, priorities.max())
+
+
+class PrioritizedReplayBufferSamples(NamedTuple):
+    """Samples from :class:`PrioritizedReplayBuffer` including weights."""
+
+    observations: th.Tensor
+    actions: th.Tensor
+    next_observations: th.Tensor
+    dones: th.Tensor
+    rewards: th.Tensor
+    weights: th.Tensor
+    indices: np.ndarray
+    discounts: Optional[th.Tensor]


### PR DESCRIPTION
## Summary
- implement proportional prioritized replay buffer
- subclass DQN to use prioritized sampling and importance weights
- wire prioritized DQN into agent and training script with configurable hyperparameters

## Testing
- `pre-commit run --files src/agent/prioritized_replay_buffer.py src/agent/prioritized_dqn.py src/agent/dqn_agent.py configs/default.yaml scripts/run_training.py`
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*
- `python - <<'PY'
import gymnasium as gym
from src.agent import DQNAgent

env = gym.make('CartPole-v1')
agent = DQNAgent(
    env,
    policy='MlpPolicy',
    buffer_size=1000,
    learning_starts=0,
    train_freq=1,
    gradient_steps=1,
    priority_alpha=0.6,
    priority_beta=0.4,
    priority_beta_increment=0.001,
    priority_eps=1e-6,
)
agent.train(50)
print('training done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c516f8214083298c76830bd76ba809