### PR TITLE
Expose gamma hyperparameter

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,7 +1,8 @@
 # Default hyper-parameters for training
 batch_size: 64
 learning_rate: 1e-4
-gamma: 0.99
+# Discount factor for future rewards.
+gamma: 0.995
 buffer_size: 100000
 train_steps: 1000000
 checkpoint_freq: 10000

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -132,6 +132,7 @@ def main() -> None:
     update_dqn_hyperparameters(
         agent.model,
         learning_rate=learning_rate,
+        gamma=gamma,
         exploration_fraction=exploration_fraction,
         exploration_final_eps=exploration_final_eps,
     )

--- a/src/training/utils.py
+++ b/src/training/utils.py
@@ -14,20 +14,25 @@ def update_dqn_hyperparameters(
     model,
     *,
     learning_rate: float,
+    gamma: float,
     exploration_fraction: float,
     exploration_final_eps: float,
 ) -> None:
     """Update learning rate and exploration schedule for a loaded DQN model.
 
     This is useful when resuming training with new hyper-parameters.
-    The optimizer's learning rate is updated and the epsilon-greedy schedule
-    is reset so that exploration anneals according to the new parameters.
+    The optimizer's learning rate is updated, the discount factor is
+    refreshed and the epsilon-greedy schedule is reset so that exploration
+    anneals according to the new parameters.
     """
     # Update learning rate for the optimizer and schedule
     model.learning_rate = learning_rate
     model.lr_schedule = lambda _: learning_rate
     for param_group in model.policy.optimizer.param_groups:
         param_group["lr"] = learning_rate
+
+    # Update discount factor
+    model.gamma = gamma
 
     # Reset exploration schedule
     model.exploration_initial_eps = 1.0


### PR DESCRIPTION
## Summary
- tune discount factor in `configs/default.yaml`
- propagate updated gamma through `run_training.py` and training utilities
- ensure resumed training applies new discount factor

## Testing
- `pre-commit run --files configs/default.yaml scripts/run_training.py src/training/utils.py`
- `pytest -q` *(passes but took ~8m)*
- `python scripts/run_training.py --config /tmp/config_995.yaml --model-path /tmp/model995.zip` *(fails: adb exec-out screencap returned non-zero exit status 255)*
- `python scripts/run_training.py --config /tmp/config_997.yaml --model-path /tmp/model997.zip` *(fails: adb exec-out screencap returned non-zero exit status 255)*

------
https://chatgpt.com/codex/tasks/task_e_68c51bdb7e788329b712f5e9639b316a