### PR TITLE
Fix exploration rate initialization for new agents

### DIFF
--- a/src/training/utils.py
+++ b/src/training/utils.py
@@ -32,8 +32,15 @@ def update_dqn_hyperparameters(
     # Update discount factor
     model.gamma = gamma
 
-    # Preserve current exploration rate instead of resetting to 1.0
+    # Preserve current exploration rate instead of resetting to 1.0. Stable-Baselines3
+    # initializes ``exploration_rate`` to ``0`` for freshly created models and
+    # only sets it to the initial epsilon on the first training step. When
+    # updating hyper-parameters before any training has happened, treat ``0`` as
+    # the initial exploration rate.
     current_eps = model.exploration_rate
+    if getattr(model, "num_timesteps", 0) == 0 and current_eps == 0:
+        current_eps = model.exploration_initial_eps
+
     prev_start = model.exploration_initial_eps
     prev_end = model.exploration_final_eps
     prev_fraction = model.exploration_fraction

--- a/tests/test_training_utils.py
+++ b/tests/test_training_utils.py
@@ -93,6 +93,29 @@ def test_update_dqn_hyperparameters() -> None:
     assert schedule(0.5) == pytest.approx(0.1)
 
 
+def test_update_dqn_hyperparameters_new_model_uses_initial_eps() -> None:
+    """For a freshly created model, default exploration rate should be 1.0."""
+    env = DummyEnv()
+    agent = DQNAgent(
+        env,
+        policy="CnnPolicy",
+        buffer_size=1,
+        learning_starts=0,
+        train_freq=1,
+        gradient_steps=1,
+    )
+    model = agent.model
+    assert model.exploration_rate == 0.0
+    update_dqn_hyperparameters(
+        model,
+        learning_rate=1e-3,
+        gamma=0.95,
+        exploration_fraction=0.5,
+        exploration_final_eps=0.1,
+    )
+    assert model.exploration_rate == pytest.approx(model.exploration_initial_eps)
+
+
 def test_load_or_create_dqn_agent_handles_space_mismatch(tmp_path) -> None:
     env = DummyEnv()
     agent = DQNAgent(


### PR DESCRIPTION
## Summary
- ensure `update_dqn_hyperparameters` treats zero exploration rate on new models as the initial epsilon
- test that fresh models start with the correct exploration rate after hyperparameter updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c524ffe9ec8329a6c3e79c6d36f9d0