### PR TITLE
Streamline episode metrics logging

### DIFF
--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -6,11 +6,24 @@ per-episode metrics to TensorBoard.
 
 from __future__ import annotations
 
+from typing import List
+
 from stable_baselines3.common.callbacks import BaseCallback
 
 
 class EpisodeMetricsCallback(BaseCallback):
-    """Log episode reward and length to TensorBoard."""
+    """Log per-episode metrics and running averages.
+
+    Episode reward and length are recorded for TensorBoard after each game
+    without printing to stdout.  At the end of each rollout the callback
+    logs the average reward and length so they appear in the regular
+    ``rollout/`` statistics.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._episode_rewards: List[float] = []
+        self._episode_lengths: List[float] = []
 
     def _on_step(self) -> bool:  # pragma: no cover - simple wrapper
         dones = self.locals.get("dones")
@@ -22,8 +35,26 @@ class EpisodeMetricsCallback(BaseCallback):
                 reward = info.get("episode_reward")
                 length = info.get("episode_length")
                 if reward is not None:
-                    self.logger.record("episode/reward", float(reward))
+                    self.logger.record(
+                        "episode/reward", float(reward), exclude="stdout"
+                    )
+                    self._episode_rewards.append(float(reward))
                 if length is not None:
-                    self.logger.record("episode/length", float(length))
+                    self.logger.record(
+                        "episode/length", float(length), exclude="stdout"
+                    )
+                    self._episode_lengths.append(float(length))
+                # Dump so values appear in TensorBoard without printing
+                # a summary box to stdout.
                 self.logger.dump(step=self.num_timesteps)
         return True
+
+    def _on_rollout_end(self) -> None:  # pragma: no cover - simple wrapper
+        if self._episode_rewards:
+            avg_reward = sum(self._episode_rewards) / len(self._episode_rewards)
+            self.logger.record("rollout/avg_reward", avg_reward)
+            self._episode_rewards.clear()
+        if self._episode_lengths:
+            avg_length = sum(self._episode_lengths) / len(self._episode_lengths)
+            self.logger.record("rollout/avg_length", avg_length)
+            self._episode_lengths.clear()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -18,6 +18,22 @@ def test_episode_metrics_callback_logs():
     }
     cb.num_timesteps = 42
     cb._on_step()
-    mock_logger.record.assert_any_call("episode/reward", 1.0)
-    mock_logger.record.assert_any_call("episode/length", 2.0)
+    mock_logger.record.assert_any_call(
+        "episode/reward", 1.0, exclude="stdout"
+    )
+    mock_logger.record.assert_any_call(
+        "episode/length", 2.0, exclude="stdout"
+    )
     mock_logger.dump.assert_called_once_with(step=42)
+
+
+def test_episode_metrics_callback_rollout_averages():
+    cb = EpisodeMetricsCallback()
+    mock_logger = Mock()
+    cb.model = Mock()
+    cb.model.logger = mock_logger
+    cb._episode_rewards = [1.0, 2.0]
+    cb._episode_lengths = [10.0, 20.0]
+    cb._on_rollout_end()
+    mock_logger.record.assert_any_call("rollout/avg_reward", 1.5)
+    mock_logger.record.assert_any_call("rollout/avg_length", 15.0)


### PR DESCRIPTION
## Summary
- Log per-episode reward and length only to TensorBoard to avoid per-game console boxes
- Track running averages of reward and length and include them in rollout stats
- Update tests for EpisodeMetricsCallback

## Testing
- `pytest tests/test_callbacks.py::test_episode_metrics_callback_logs -q`
- `pytest tests/test_callbacks.py::test_episode_metrics_callback_rollout_averages -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c52c3b895c8329ad7a0f487ee69b85