### PR TITLE
Avoid empty logger dumps

### DIFF
--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -34,19 +34,23 @@ class EpisodeMetricsCallback(BaseCallback):
             if done:
                 reward = info.get("episode_reward")
                 length = info.get("episode_length")
+                has_log = False
                 if reward is not None:
                     self.logger.record(
                         "episode/reward", float(reward), exclude="stdout"
                     )
                     self._episode_rewards.append(float(reward))
+                    has_log = True
                 if length is not None:
                     self.logger.record(
                         "episode/length", float(length), exclude="stdout"
                     )
                     self._episode_lengths.append(float(length))
-                # Dump so values appear in TensorBoard without printing
-                # a summary box to stdout.
-                self.logger.dump(step=self.num_timesteps)
+                    has_log = True
+                if has_log:
+                    # Dump so values appear in TensorBoard without printing
+                    # a summary box to stdout.
+                    self.logger.dump(step=self.num_timesteps)
         return True
 
     def _on_rollout_end(self) -> None:  # pragma: no cover - simple wrapper

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -37,3 +37,15 @@ def test_episode_metrics_callback_rollout_averages():
     cb._on_rollout_end()
     mock_logger.record.assert_any_call("rollout/avg_reward", 1.5)
     mock_logger.record.assert_any_call("rollout/avg_length", 15.0)
+
+
+def test_episode_metrics_callback_no_dump_without_metrics():
+    """Logger.dump should not be called if no metrics were recorded."""
+    cb = EpisodeMetricsCallback()
+    mock_logger = Mock()
+    cb.model = Mock()
+    cb.model.logger = mock_logger
+    cb.locals = {"dones": [True], "infos": [{}]}
+    cb.num_timesteps = 0
+    cb._on_step()
+    mock_logger.dump.assert_not_called()


### PR DESCRIPTION
## Summary
- prevent EpisodeMetricsCallback from calling logger.dump when no episode metrics were recorded
- add regression test to ensure no dumping happens without metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c558c9d88483299ba686d6aee4a952