### PR TITLE
revert episode logging console output

### DIFF
--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import List
 
-import logging
 from stable_baselines3.common.callbacks import BaseCallback
 
 
@@ -52,12 +51,6 @@ class EpisodeMetricsCallback(BaseCallback):
                     # Dump so values appear in TensorBoard without printing
                     # a summary box to stdout.
                     self.logger.dump(step=self.num_timesteps)
-                    if reward is not None and length is not None:
-                        logging.info(
-                            "Episode finished: reward=%.2f length=%d",
-                            float(reward),
-                            int(length),
-                        )
         return True
 
     def _on_rollout_end(self) -> None:  # pragma: no cover - simple wrapper


### PR DESCRIPTION
## Summary
- revert the logging changes introduced in PR #50 so episodes no longer log to the console

## Testing
- `pre-commit run --files src/training/callbacks.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c55c040a308329965b68ac24f16e2e