### PR TITLE
Use Save Me dialog template for crash detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ By default the script evaluates the latest checkpoint found under
   `(520, 1700)`. Use this script to adjust these coordinates for your device.
 - `scripts/capture_template.py` — save the current emulator screen to a PNG
   file. Capture reference images of the menu and crash screens and store them
-  as `templates/menu_full.png` and `templates/crash_full.png`; the environment will use
-  template matching to detect when it should tap the PLAY button or dismiss
-  the *Save Me?* dialog.
+  as `templates/menu_full.png` and `templates/templates_crash_full.png`; the
+  environment will use template matching to detect when it should tap the PLAY
+  button or dismiss the *Save Me?* dialog.
 
 During play and training, the environment logs the current game state (menu,
 playing, or crashed) to the terminal every couple of seconds, which helps

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ This document will track design decisions and architecture diagrams for the Subw
   - `SubwaySurfersEnv` exposes a Gymnasium-compatible interface built on top of
     `ADBController` for training and evaluation. It automatically taps the
     menu **PLAY** button and dismisses the *Save Me?* dialog using template
-    matching with `templates/menu_full.png` and `templates/crash_full.png`
+    matching with `templates/menu_full.png` and `templates/templates_crash_full.png`
     (falling back to color checks if templates are missing). It logs the
     current game state every few seconds, retries tapping **PLAY** if the game
     stays on the menu for more than five seconds, and measures rewards based on

--- a/src/env/subway_env.py
+++ b/src/env/subway_env.py
@@ -38,8 +38,8 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
     The environment communicates with an Android emulator via ``ADBController``.
     Observations are RGB frames resized to ``frame_size``. Actions are discrete
     swipes: left, right, jump, roll. If ``templates/menu_full.png`` and
-    ``templates/crash_full.png`` exist, they are used for template matching to
-    detect the menu and crash screens. The environment logs the detected game
+    ``templates/templates_crash_full.png`` exist, they are used for template matching
+    to detect the menu and crash screens. The environment logs the detected game
     state every ``state_log_interval`` seconds.
     """
 
@@ -49,7 +49,7 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
         default_factory=lambda: DEFAULT_ACTION_COORDS.copy()
     )
     menu_template_path: Optional[Path] = Path("templates/menu_full.png")
-    crash_template_path: Optional[Path] = Path("templates/crash_full.png")
+    crash_template_path: Optional[Path] = Path("templates/templates_crash_full.png")
     menu_template: Optional[np.ndarray] = field(init=False, default=None)
     crash_template: Optional[np.ndarray] = field(init=False, default=None)
     state_log_interval: float = 2.0
@@ -114,10 +114,8 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
         return g > 150 and r < 100 and b < 100
 
     def _is_crash(self, image: Image.Image) -> bool:
-        if self.crash_template is not None and self._match_template(
-            image, self.crash_template
-        ):
-            return True
+        if self.crash_template is not None:
+            return self._match_template(image, self.crash_template)
         try:
             np_img = np.array(image)
         except Exception:


### PR DESCRIPTION
## Summary
- switch crash screen template to `templates_crash_full.png`
- rely on template matching when present to avoid false crash detections
- document new template name in README and architecture docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c564c65b348329a5e63b74cd528965