### PR TITLE
Reduce menu retry delay after crash

### DIFF
--- a/src/env/subway_env.py
+++ b/src/env/subway_env.py
@@ -53,6 +53,7 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
     menu_template: Optional[np.ndarray] = field(init=False, default=None)
     crash_template: Optional[np.ndarray] = field(init=False, default=None)
     state_log_interval: float = 2.0
+    menu_retry_delay: float = 1.0
     _last_state_log: float = field(init=False, default_factory=lambda: 0.0)
     _episode_reward: float = field(init=False, default_factory=lambda: 0.0)
     _episode_length: int = field(init=False, default_factory=lambda: 0)
@@ -191,7 +192,7 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
         if state == "menu":
             if self._menu_since is None:
                 self._menu_since = now
-            elif now - self._menu_since > 5.0:
+            elif now - self._menu_since > self.menu_retry_delay:
                 self.controller.tap(*PLAY_BUTTON_COORD)
                 self._menu_since = now
             observation = self._preprocess(image)

--- a/tests/test_subway_env.py
+++ b/tests/test_subway_env.py
@@ -138,10 +138,10 @@ def test_menu_retry_after_timeout(monkeypatch):
     env = SubwaySurfersEnv(controller=controller)
     env.reset()
 
-    times = iter([0.0, 0.0, 6.0, 6.0])
+    times = iter([0.0, 0.0, 1.1, 1.1])
     monkeypatch.setattr(time, "time", lambda: next(times))
     env.step(0)  # first menu detection, set _menu_since
-    env.step(0)  # after 6s, should tap again
+    env.step(0)  # after timeout, should tap again
     controller.tap.assert_called_with(*PLAY_BUTTON_COORD)
 
 


### PR DESCRIPTION
## Summary
- retry tapping the play button sooner by default
- adjust menu retry timeout test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56dcbae3883298a0133e298733328