### PR TITLE
Log episode stats when game ends

### DIFF
--- a/src/env/subway_env.py
+++ b/src/env/subway_env.py
@@ -217,7 +217,11 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
                     "episode_reward": self._episode_reward,
                     "episode_length": self._episode_length,
                 }
-                LOGGER.info("game finished")
+                LOGGER.info(
+                    "game finished     reward:%s     length:%s",
+                    self._episode_reward,
+                    self._episode_length,
+                )
                 self._episode_reward = 0.0
                 self._episode_length = 0
             self._menu_since = None
@@ -252,7 +256,11 @@ class SubwaySurfersEnv(gym.Env[np.ndarray, int]):
         observation = self._preprocess(image)
         info: Dict[str, float] = {"steps_survived": self._episode_length}
         if terminated:
-            LOGGER.info("game finished")
+            LOGGER.info(
+                "game finished     reward:%s     length:%s",
+                self._episode_reward,
+                self._episode_length,
+            )
             info = {
                 "steps_survived": self._episode_length,
                 "episode_reward": self._episode_reward,

--- a/tests/test_subway_env.py
+++ b/tests/test_subway_env.py
@@ -171,7 +171,12 @@ def test_episode_end_logs_length_and_reward(caplog, monkeypatch):
     env.reset()
     with caplog.at_level(logging.INFO):
         env.step(0)
-    assert "game finished" in caplog.text.lower()
+    assert any(
+        "game finished" in record.message
+        and "reward:-1.0" in record.message
+        and "length:1" in record.message
+        for record in caplog.records
+    )
 
 
 def test_no_extra_reward_or_log_after_crash(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- Include episode reward and length in `game finished` log output
- Adjust tests to assert new `game finished` log content

## Testing
- `pytest tests/test_subway_env.py::test_episode_end_logs_length_and_reward -q`
- `pytest tests/test_subway_env.py::test_no_extra_reward_or_log_after_crash -q`


------
https://chatgpt.com/codex/tasks/task_e_68c822b394ec8329a4120f4784bb168a