### PR TITLE
Limit checkpoints to latest and adjust frequency

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -5,7 +5,7 @@ learning_rate: 1e-4
 gamma: 0.995
 buffer_size: 100000
 train_steps: 1000000
-checkpoint_freq: 10000
+checkpoint_freq: 1000
 exploration_fraction: 0.2
 exploration_final_eps: 0.02
 priority_alpha: 0.6

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -10,7 +10,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 import yaml
-from stable_baselines3.common.callbacks import CheckpointCallback, CallbackList
+from stable_baselines3.common.callbacks import CallbackList
 from stable_baselines3.common.logger import configure
 from stable_baselines3.common.vec_env import DummyVecEnv, VecFrameStack
 
@@ -21,7 +21,10 @@ if str(ROOT) not in sys.path:
 
 from src.agent import DQNAgent  # noqa: E402
 from src.env import SubwaySurfersEnv  # noqa: E402
-from src.training import EpisodeMetricsCallback  # noqa: E402
+from src.training import (  # noqa: E402
+    EpisodeMetricsCallback,
+    LatestCheckpointCallback,
+)
 from src.training.utils import (  # noqa: E402
     update_dqn_hyperparameters,
     load_or_create_dqn_agent,
@@ -149,8 +152,8 @@ def main() -> None:
     # Setup checkpointing
     checkpoint_dir = model_file.parent / "checkpoints"
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
-    checkpoint_callback = CheckpointCallback(
-        save_freq=int(cfg.get("checkpoint_freq", 10000)),
+    checkpoint_callback = LatestCheckpointCallback(
+        save_freq=int(cfg.get("checkpoint_freq", 1000)),
         save_path=str(checkpoint_dir),
         name_prefix=model_file.stem,
         save_replay_buffer=True,

--- a/src/training/__init__.py
+++ b/src/training/__init__.py
@@ -1,3 +1,3 @@
-from .callbacks import EpisodeMetricsCallback
+from .callbacks import EpisodeMetricsCallback, LatestCheckpointCallback
 
-__all__ = ["EpisodeMetricsCallback"]
+__all__ = ["EpisodeMetricsCallback", "LatestCheckpointCallback"]

--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -6,9 +6,11 @@ per-episode metrics to TensorBoard.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from typing import List
 
-from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.callbacks import BaseCallback, CheckpointCallback
 
 
 class EpisodeMetricsCallback(BaseCallback):
@@ -62,3 +64,146 @@ class EpisodeMetricsCallback(BaseCallback):
             avg_length = sum(self._episode_lengths) / len(self._episode_lengths)
             self.logger.record("rollout/avg_length", avg_length)
             self._episode_lengths.clear()
+
+
+class LatestCheckpointCallback(CheckpointCallback):
+    """Keep only the most recent checkpoint on disk."""
+
+    _STEP_PATTERN = re.compile(r"_(\d+)_steps")
+
+    def _init_callback(self) -> None:
+        super()._init_callback()
+        self._prune_existing_checkpoints()
+
+    def _on_step(self) -> bool:
+        if self.n_calls % self.save_freq == 0:
+            model_path = Path(self._checkpoint_path(extension="zip"))
+            self.model.save(str(model_path))
+            if self.verbose >= 2:
+                print(f"Saving model checkpoint to {model_path}")
+
+            replay_buffer_path: Path | None = None
+            if (
+                self.save_replay_buffer
+                and hasattr(self.model, "replay_buffer")
+                and self.model.replay_buffer is not None
+            ):
+                replay_buffer_path = Path(
+                    self._checkpoint_path("replay_buffer_", extension="pkl")
+                )
+                self.model.save_replay_buffer(str(replay_buffer_path))
+                if self.verbose > 1:
+                    print(
+                        "Saving model replay buffer checkpoint to"
+                        f" {replay_buffer_path}"
+                    )
+
+            vecnormalize_path: Path | None = None
+            vec_env = self.model.get_vec_normalize_env()
+            if self.save_vecnormalize and vec_env is not None:
+                vecnormalize_path = Path(
+                    self._checkpoint_path("vecnormalize_", extension="pkl")
+                )
+                vec_env.save(str(vecnormalize_path))
+                if self.verbose >= 2:
+                    print(
+                        "Saving model VecNormalize to"
+                        f" {vecnormalize_path}"
+                    )
+
+            self._cleanup_old_checkpoints(
+                keep_model=model_path,
+                keep_replay_buffer=replay_buffer_path,
+                keep_vecnormalize=vecnormalize_path,
+            )
+
+        return True
+
+    def _prune_existing_checkpoints(self) -> None:
+        if self.save_path is None:
+            return
+
+        checkpoint_dir = Path(self.save_path)
+        latest_model = self._find_latest_checkpoint(
+            checkpoint_dir, suffix="zip", checkpoint_type=""
+        )
+        latest_step = self._extract_step(latest_model) if latest_model else None
+
+        latest_replay = self._find_latest_checkpoint(
+            checkpoint_dir,
+            suffix="pkl",
+            checkpoint_type="replay_buffer_",
+            preferred_step=latest_step,
+        )
+        latest_vecnormalize = self._find_latest_checkpoint(
+            checkpoint_dir,
+            suffix="pkl",
+            checkpoint_type="vecnormalize_",
+            preferred_step=latest_step,
+        )
+
+        self._cleanup_old_checkpoints(
+            keep_model=latest_model,
+            keep_replay_buffer=latest_replay,
+            keep_vecnormalize=latest_vecnormalize,
+        )
+
+    def _find_latest_checkpoint(
+        self,
+        checkpoint_dir: Path,
+        *,
+        suffix: str,
+        checkpoint_type: str,
+        preferred_step: int | None = None,
+    ) -> Path | None:
+        pattern = f"{self.name_prefix}_{checkpoint_type}*_steps.{suffix}"
+        candidates = sorted(
+            checkpoint_dir.glob(pattern),
+            key=self._extract_step,
+            reverse=True,
+        )
+        if not candidates:
+            return None
+
+        if preferred_step is not None:
+            for candidate in candidates:
+                if self._extract_step(candidate) == preferred_step:
+                    return candidate
+
+        return candidates[0]
+
+    def _extract_step(self, path: Path | None) -> int:
+        if path is None:
+            return -1
+        match = self._STEP_PATTERN.search(path.name)
+        if match is None:
+            return -1
+        return int(match.group(1))
+
+    def _cleanup_old_checkpoints(
+        self,
+        *,
+        keep_model: Path | None,
+        keep_replay_buffer: Path | None,
+        keep_vecnormalize: Path | None,
+    ) -> None:
+        if self.save_path is None:
+            return
+
+        checkpoint_dir = Path(self.save_path)
+
+        for path in checkpoint_dir.glob(f"{self.name_prefix}_*_steps.zip"):
+            if keep_model is None or path != keep_model:
+                path.unlink(missing_ok=True)
+
+        for path in checkpoint_dir.glob(
+            f"{self.name_prefix}_replay_buffer_*_steps.pkl"
+        ):
+            if keep_replay_buffer is None or path != keep_replay_buffer:
+                path.unlink(missing_ok=True)
+
+        for path in checkpoint_dir.glob(
+            f"{self.name_prefix}_vecnormalize_*_steps.pkl"
+        ):
+            if keep_vecnormalize is None or path != keep_vecnormalize:
+                path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add a LatestCheckpointCallback that removes outdated checkpoint and replay-buffer files so only the newest pair remains on disk
- switch the training script to use the new callback and lower the default checkpoint frequency to every 1k steps
- update the default configuration to reflect the new checkpoint frequency

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f08e22f88329b13e07ca9b1e35c6